### PR TITLE
Added a simple 'download all images' implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-
+.vs
+.vscode
 node_modules
+package-lock.json
+.eslintrc.json

--- a/imagehelper.js
+++ b/imagehelper.js
@@ -1,0 +1,32 @@
+const request = require('request')
+
+function getAllImages(html) {
+    var m, urls = [], rex = /<img[^>]+src="?([^"\s]+)"?[^>]*\/>/g
+    while (m = rex.exec(html)) {
+        var parts = m[1].split('/')
+        var imageName = parts[parts.length - 1]
+        urls.push({ originalPath: m[1], imageName: imageName });
+    }
+
+    return urls
+}
+
+function downloadImageBinary(url, newPath) {
+    return new Promise((resolve, reject) => {
+        request({
+            followAllRedirects: true,
+            url: url,
+            encoding: null
+        }, function (error, response, body) {
+            if (error) {
+                reject(error)
+            }
+            resolve({ buffer: body, newPath })
+        })
+    })
+}
+
+module.exports = {
+    getAllImages,
+    downloadImageBinary
+}

--- a/noddity-wordpress-export.js
+++ b/noddity-wordpress-export.js
@@ -3,6 +3,8 @@ var us = require('underscore')
 var xml2js = require('xml2js')
 var parser = new xml2js.Parser()
 var toMarkdown = require('to-markdown').toMarkdown
+var imagehelper = require('./imagehelper.js')
+var JSZip = require("jszip")
 
 var postFilter = require('./post-filter.js')
 
@@ -12,26 +14,28 @@ if (process.argv[2] === undefined) {
 	return
 }
 
-var settings = {
+const settings = {
 	fileName: process.argv[2],
-	fileEncoding: 'utf8'
+	fileEncoding: 'utf8',
+	outputFile: 'output.zip',
+	downloadAllImageFiles: false,
+	logDownloadedFiles: true,
+	logErrorsOnDownloading: true
 }
 
-var pad = function(n){ return n < 10 ? '0' + n : n }
 
-
+var pad = function (n) { return n < 10 ? '0' + n : n }
 fs.readFile(settings.fileName, settings.fileEncoding, function (err, data) {
 	if (!err) {
 		parser.parseString(data, function (err, result) {
 			createFiles(parseChannel(result.rss.channel[0]))
-			console.log('...Done!')
 		})
 	} else {
 		console.log('Error reading file')
 	}
 })
 
-var parseChannel = function(channel) {
+var parseChannel = function (channel) {
 	var blog = {}
 
 	// set the singletons
@@ -43,9 +47,9 @@ var parseChannel = function(channel) {
 	// parse authors
 	var wp_authors = channel['wp:author']
 	var authors = []
-	us.map(wp_authors, function(wp_author){
+	us.map(wp_authors, function (wp_author) {
 		var author = {}
-		author.id = wp_author['wp:author_id'][0]
+		author.id = wp_author['wp:author_id'] ? wp_author['wp:author_id'][0] : ''
 		author.login = wp_author['wp:author_login'][0]
 		author.email = wp_author['wp:author_email'][0]
 		author.display_name = wp_author['wp:author_display_name'][0]
@@ -58,9 +62,9 @@ var parseChannel = function(channel) {
 
 	// parse posts
 	var posts = []
-	us.map(channel.item, function(item){
+	us.map(channel.item, function (item) {
 		var post = parsePost(item)
-		us.map(blog.authors, function(author) {
+		us.map(blog.authors, function (author) {
 			if (author.login === post.author) {
 				post.author = author
 			}
@@ -72,7 +76,7 @@ var parseChannel = function(channel) {
 	return blog
 }
 
-var parsePost = function(wp_post) {
+var parsePost = function (wp_post) {
 	// singletons
 	var post = {}
 	post.title = wp_post.title[0]
@@ -81,6 +85,16 @@ var parsePost = function(wp_post) {
 	post.author = wp_post['dc:creator'][0]
 	post.permalink = wp_post.guid[0]._
 	post.content = (typeof wp_post['content:encoded'][0] === 'object' ? null : wp_post['content:encoded'][0])
+
+	if (settings.downloadAllImageFiles) {
+		post.imagePaths = imagehelper.getAllImages(post.content)
+
+		post.imagePaths.forEach(function (element) {
+			post.content = post.content.replace(element.originalPath, 'images/' + element.imageName)
+		})
+	}
+
+
 	post.markdown = (post.content === null ? null : toMarkdown(post.content))
 	post.excerpt = (typeof wp_post['excerpt:encoded'][0] === 'object' ? null : wp_post['excerpt:encoded'][0])
 	post.id = Number(wp_post['wp:post_id'][0])
@@ -93,9 +107,9 @@ var parsePost = function(wp_post) {
 	// categories and tags are like [{url_safe, print_name}]
 	var categories = []
 	var tags = []
-	if(typeof wp_post.category !== 'undefined') {
-		us.map(wp_post.category, function(unknown){
-			var obj = { url_safe : unknown.$.nicename, print_name : unknown._ }
+	if (typeof wp_post.category !== 'undefined') {
+		us.map(wp_post.category, function (unknown) {
+			var obj = { url_safe: unknown.$.nicename, print_name: unknown._ }
 			if (unknown.$.domain === 'category') {
 				categories.push(obj)
 			}
@@ -110,14 +124,13 @@ var parsePost = function(wp_post) {
 	return post
 }
 
-var postFormatter = function(post) {
+var postFormatter = function (post) {
 	// before the user muddles with things, let's make a default folder and file name
 	var date = (isNaN(post.published_date.valueOf()) ? new Date() : post.published_date)
 	var folder = (isNaN(post.published_date.valueOf())
 		? "unpublished/"
 		: (post.is_post ? "posts/" : "pages/") + date.getUTCFullYear() + "/" + pad(date.getUTCMonth() + 1) + "/")
-	var fileName = (typeof post.slug !== 'string' ? post.id : post.slug ) + ".md"
-	var media_folder_hierarchy = {} // TODO figure this out, I reckon
+	var fileName = (typeof post.slug !== 'string' ? post.id : post.slug) + ".md"
 
 	// run the user definable filter
 	postFilter(post)
@@ -143,10 +156,10 @@ var postFormatter = function(post) {
 	// you can change the way the date is stored, but it should be parsable by the Date function
 	if (undefined === post.published_date_string && undefined !== post.published_date) {
 		var dateString = post.published_date.getUTCFullYear() + "-" + pad(post.published_date.getUTCMonth() + 1) + "-" + pad(post.published_date.getUTCDate() + 1)
-			+ " " + pad(post.published_date.getUTCHours()) + ":"+ pad(post.published_date.getUTCMinutes())
+			+ " " + pad(post.published_date.getUTCHours()) + ":" + pad(post.published_date.getUTCMinutes())
 		finalPost.date = dateString
 	} else {
-		finalPost.date = published_date_string
+		finalPost.date = post.published_date_string
 	}
 
 	if (undefined !== post.link) {
@@ -183,7 +196,7 @@ var postFormatter = function(post) {
 	// categories by comma separated on url safe name, e.g. "things_i_say, other"
 	if (undefined === post.categories_string && undefined !== post.categories) {
 		var categories = ""
-		us.map(post.categories, function(category) {
+		us.map(post.categories, function (category) {
 			categories = categories + (categories.length > 0 ? ", " : "") + category.url_safe
 		})
 		finalPost.categories = categories
@@ -194,7 +207,7 @@ var postFormatter = function(post) {
 	// tags the same as categories
 	if (undefined === post.tags_string && undefined !== post.tags) {
 		var tags = ""
-		us.map(post.tags, function(tag) {
+		us.map(post.tags, function (tag) {
 			tags = tags + (tags.length > 0 ? ", " : "") + tag.url_safe
 		})
 		finalPost.tags = tags
@@ -209,6 +222,7 @@ var postFormatter = function(post) {
 		finalPost.folder = post.folder
 	}
 
+
 	// default file name
 	if (undefined === post.fileName) {
 		finalPost.fileName = fileName
@@ -216,23 +230,22 @@ var postFormatter = function(post) {
 		finalPost.fileName = post.fileName
 	}
 
-	// default to not download all media
-	if (post.download_media) {
-		// TODO: somehow we need to download the files, or something
-		//post.media_folder_hierarchy
-	}
+	finalPost.imagePaths = post.imagePaths || []
 
 	return finalPost
 }
 
-var createFiles = function(blog) {
+var createFiles = function (blog) {
 	// why a zip file? because I said so
-	var zip = new require('node-zip')()
-	us.map(blog.posts, function(post) {
+	var zip = new JSZip()
+
+	var promisesToDownloadImages = []
+
+	us.map(blog.posts, function (post) {
 		// create the string that goes into the file
 		// create the metadata text string
 		var text = ""
-		us.map(us.keys(post), function(key){
+		us.map(us.keys(post), function (key) {
 			if (key !== 'content' && key !== 'folder' && key !== 'fileName') {
 				text = text + key + ": " + post[key] + "\n"
 			}
@@ -242,10 +255,38 @@ var createFiles = function(blog) {
 		// content string
 		text = text + post.content
 
+		var promises = post.imagePaths.map(function (element) {
+			return imagehelper.downloadImageBinary(element.originalPath, post.folder + 'images/' + element.imageName)
+		})
+
+		promises.forEach(function (element) {
+			promisesToDownloadImages.push(element)
+		})
+
 		zip.file(post.folder + post.fileName, text)
 	})
-	
-	// output file
-	var data = zip.generate({base64:false,compression:'DEFLATE'})
-	fs.writeFile('output.zip', data, 'binary')
+
+	//.map is used because we want promises to continue exeuting even if one of them fails
+	//e.g. cannot download an image due to 404. source: https://stackoverflow.com/questions/31424561/wait-until-all-es6-promises-complete-even-rejected-promises/36115549#36115549
+	Promise.all(promisesToDownloadImages.map(p => p.catch(e =>
+	{ if (settings.logErrorsOnDownloading) console.log(e); return e; })))
+		.then((results) => {
+			results.forEach((element) => {
+				if (settings.logDownloadedFiles) {
+					console.log(`downloaded ${element.newPath}`)
+				}
+				if (element.buffer) {//if we have something
+					console.log(`zipping ${element.newPath}`)
+					zip.file(element.newPath, element.buffer.toString('base64'), { base64: true })
+				}
+			})
+
+			zip.generateNodeStream({ type: 'nodebuffer', streamFiles: true })
+				.pipe(fs.createWriteStream(settings.outputFile))
+				.on('finish', function () {
+					// JSZip generates a readable stream with a "end" event,
+					// but is piped here in a writable stream which emits a "finish" event.
+					console.log('done!')
+				})
+		}).catch(e => console.log(e))
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noddity-wordpress-export",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "bin": "./noddity-wordpress-export.js",
   "author": {
     "name": "Tobias Davis",
@@ -17,9 +17,10 @@
     "url": "https://github.com/saibotsivad/noddity-wordpress-export.git"
   },
   "dependencies": {
-    "xml2js": "~0.2.2",
+    "jszip": "^3.1.3",
+    "request": "^2.81.0",
     "to-markdown": "0.0.1",
     "underscore": "~1.4.3",
-    "node-zip": "0.0.2"
+    "xml2js": "~0.2.2"
   }
 }


### PR DESCRIPTION
I recently needed to convert one of my wordpress posts to GitHub markdown and I found this library, thanks for the great work! I needed to have the blog post images embedded to the GitHub repo, so I modified the script to add this functionality. I used jszip directly, hope it's OK!
